### PR TITLE
feat: 支持 dddd-trainer 自定义模型

### DIFF
--- a/ddddocr/types.go
+++ b/ddddocr/types.go
@@ -14,11 +14,13 @@ type Config struct {
 	DetModelPath       string
 	DictPath           string
 	OnnxRuntimeLibPath string
+	UseCustomModel     bool // true = 使用自定义模型 (dddd-trainer)
 }
 
 // Engine ddddocr 引擎
 type Engine struct {
-	ocrSession *ort.Session
-	detSession *ort.Session
-	dict       []string
+	ocrSession     *ort.Session
+	detSession     *ort.Session
+	dict           []string
+	useCustomModel bool
 }

--- a/examples/ddddocr_test.go
+++ b/examples/ddddocr_test.go
@@ -39,6 +39,34 @@ func TestDdddOcr_Classification(t *testing.T) {
 	t.Logf("识别完成, 耗时：%v, 识别内容：%v\n", time.Since(start), res)
 }
 
+func TestDdddOcr_Classification_CustomModel(t *testing.T) {
+	start := time.Now()
+	config := ddddocr.Config{
+		OnnxRuntimeLibPath: "../lib/onnxruntime.dll",
+		ModelPath:          "../ddddocr_weights/my_model.onnx",
+		DictPath:           "../ddddocr_weights/my_charsets.json",
+		UseCustomModel:     true,
+	}
+
+	engine, err := ddddocr.NewEngine(config)
+	if err != nil {
+		log.Fatalf("创建 OCR 引擎失败: %v\n", err)
+	}
+	defer engine.Destroy()
+
+	imagePath := "./captcha.png"
+	img, err := imageutil.Open(imagePath)
+	if err != nil {
+		log.Fatalf("加载图像失败: %v\n", err)
+	}
+
+	res, err := engine.Classification(img)
+	if err != nil {
+		log.Fatalf("运行识别失败: %v\n", err)
+	}
+	t.Logf("识别完成, 耗时：%v, 识别内容：%v\n", time.Since(start), res)
+}
+
 func TestDdddOcr_Detect(t *testing.T) {
 	start := time.Now()
 	config := ddddocr.Config{


### PR DESCRIPTION
- 新增 UseCustomModel 配置选项
- 修复图像预处理的 Stride 问题
- 支持自定义模型的标准化参数 (x - 0.456) / 0.224
- 支持自定义模型的输出节点名 "output" 和 int64 数据类型
- 添加自定义模型专用的 CTC 后处理逻辑
- 添加自定义模型测试示例